### PR TITLE
Use AddUserSecrets to secure development environments

### DIFF
--- a/tests/Mscc.GenerativeAI/ConfigurationFixture.cs
+++ b/tests/Mscc.GenerativeAI/ConfigurationFixture.cs
@@ -32,6 +32,7 @@ namespace Test.Mscc.GenerativeAI
                 .AddJsonFile("appsettings.user.json", optional: true)
                 .AddJsonFile(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "gcloud",
                         "application_default_credentials.json"), optional: true)
+                .AddUserSecrets("b2e3f388-3f81-435b-9467-73081761ab6f") // Add User Secrets
                 .AddEnvironmentVariables()
                 .Build();
 

--- a/tests/Mscc.GenerativeAI/Test.Mscc.GenerativeAI.csproj
+++ b/tests/Mscc.GenerativeAI/Test.Mscc.GenerativeAI.csproj
@@ -6,6 +6,7 @@
 		<NoWarn>$(NoWarn);CS0618;NU1701</NoWarn>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
+		<UserSecretsId>b2e3f388-3f81-435b-9467-73081761ab6f</UserSecretsId>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0')) or $(TargetFramework.StartsWith('net7.0')) or $(TargetFramework.StartsWith('net8.0'))">
@@ -36,6 +37,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="xunit" Version="2.7.0" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />


### PR DESCRIPTION
Use **User Secrets** to store apikey in the unit test project for better security dev environment setup.

Reference: [Safe storage of app secrets in development in ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-8.0&tabs=windows&WT.mc_id=DT-MVP-4015686)