### PR TITLE
Make clients thread safe and allow custom response schema

### DIFF
--- a/src/Mscc.GenerativeAI/BaseModel.cs
+++ b/src/Mscc.GenerativeAI/BaseModel.cs
@@ -7,6 +7,7 @@ using System.Security.Authentication;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
+using System.Threading;
 #endif
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
@@ -75,32 +76,34 @@ namespace Mscc.GenerativeAI
         /// <remarks>
         /// The value can only be set or modified before the first request is made.
         /// </remarks>
-        public virtual string? ApiKey
+        public virtual string? ApiKey { set => _apiKey = value; }
+
+        protected virtual void AddApiKeyHeader(HttpRequestMessage request)
         {
-            set
+            if (!string.IsNullOrEmpty(_apiKey))
             {
-                _apiKey = value;
-                if (!string.IsNullOrEmpty(_apiKey))
+                if (request.Headers.Contains("x-goog-api-key"))
                 {
-                    if (Client.DefaultRequestHeaders.Contains("x-goog-api-key"))
-                    {
-                        Client.DefaultRequestHeaders.Remove("x-goog-api-key");
-                    }
-                    Client.DefaultRequestHeaders.Add("x-goog-api-key", _apiKey);
+                    request.Headers.Remove("x-goog-api-key");
                 }
+                request.Headers.Add("x-goog-api-key", _apiKey);
             }
         }
         
         /// <summary>
         /// Sets the access token to use for the request.
         /// </summary>
-        public string? AccessToken
+        public string? AccessToken { set => _accessToken = value; }
+        
+        protected virtual void AddAccessTokenHeader(HttpRequestMessage request)
         {
-            set
+            if (!string.IsNullOrEmpty(_accessToken))
             {
-                _accessToken = value;
-                if (value != null)
-                    Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
+                if (request.Headers.Contains("Authorization"))
+                {
+                    request.Headers.Remove("Authorization");
+                }
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
             }
         }
         
@@ -110,19 +113,16 @@ namespace Mscc.GenerativeAI
         /// <remarks>
         /// The value can only be set or modified before the first request is made.
         /// </remarks>
-        public string? ProjectId
+        public string? ProjectId { set => _projectId = value; }
+        protected virtual void AddProjectIdHeader(HttpRequestMessage request)
         {
-            set
+            if (!string.IsNullOrEmpty(_projectId))
             {
-                _projectId = value;
-                if (!string.IsNullOrEmpty(_projectId))
+                if (request.Headers.Contains("x-goog-user-project"))
                 {
-                    if (Client.DefaultRequestHeaders.Contains("x-goog-user-project"))
-                    {
-                        Client.DefaultRequestHeaders.Remove("x-goog-user-project");
-                    }
-                    Client.DefaultRequestHeaders.Add("x-goog-user-project", _projectId);
+                    request.Headers.Remove("x-goog-user-project");
                 }
+                request.Headers.Add("x-goog-user-project", _projectId);
             }
         }
 
@@ -149,13 +149,24 @@ namespace Mscc.GenerativeAI
         /// </summary>
         protected virtual void ThrowIfUnsupportedRequest<T>(T request) { }
 
+        // Instance fields for default headers
+        private readonly ProductInfoHeaderValue _defaultUserAgent;
+        private readonly KeyValuePair<string, string> _defaultApiClientHeader;
+
         /// <summary>
         /// 
         /// </summary>
         /// <param name="logger">Optional. Logger instance used for logging</param>
         public BaseModel(ILogger? logger = null) : base(logger)
         {
-            SetDefaultRequestHeaders();
+            // Initialize the default headers in constructor
+            var productHeaderValue = new ProductHeaderValue(
+                name: Assembly.GetExecutingAssembly().GetName().Name ?? "Mscc.GenerativeAI", 
+                version: Assembly.GetExecutingAssembly().GetName().Version?.ToString());
+            _defaultUserAgent = new ProductInfoHeaderValue(productHeaderValue);
+            _defaultApiClientHeader = new KeyValuePair<string, string>(
+                "x-goog-api-client", 
+                _defaultUserAgent.ToString());
             _options = DefaultJsonSerializerOptions();
             GenerativeAIExtensions.ReadDotEnv();
             ApiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
@@ -256,21 +267,6 @@ namespace Mscc.GenerativeAI
             var json = await response.Content.ReadAsStringAsync();
             return await response.Content.ReadFromJsonAsync<T>(_options);
 #endif
-        }
-
-        /// <summary>
-        /// Set default request headers of <see cref="HttpClient"/>.
-        /// </summary>
-        private void SetDefaultRequestHeaders()
-        {
-            // ('x-goog-api-client', 'genai-py/0.8.2 gl-python/3.12.3 grpc/1.68.0 gax/2.23.0')
-            // ('x-goog-request-params', 'model=models/imagen-3.0-generate-001')
-            var productHeaderValue = new ProductHeaderValue(
-                name: Assembly.GetExecutingAssembly().GetName().Name ?? "Mscc.GenerativeAI", 
-                version: Assembly.GetExecutingAssembly().GetName().Version?.ToString());
-            var productInfoHeaderValue = new ProductInfoHeaderValue(productHeaderValue);
-            Client.DefaultRequestHeaders.UserAgent.Add(productInfoHeaderValue);
-            Client.DefaultRequestHeaders.Add(name: "x-goog-api-client", productInfoHeaderValue.ToString());
         }
 
         /// <summary>
@@ -415,5 +411,28 @@ namespace Mscc.GenerativeAI
                 ((string.IsNullOrEmpty(arguments)) ? string.Empty : " " + arguments) +
                 "'";
         }
-   }
+
+        protected async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
+        {
+            // Add auth headers specific to this request
+            if (!string.IsNullOrEmpty(_apiKey))
+            {
+                request.Headers.Add("x-goog-api-key", _apiKey);
+            }
+            if (!string.IsNullOrEmpty(_accessToken))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
+            }
+            if (!string.IsNullOrEmpty(_projectId))
+            {
+                request.Headers.Add("x-goog-user-project", _projectId);
+            }
+
+            // Add instance default headers
+            request.Headers.UserAgent.Add(_defaultUserAgent);
+            request.Headers.Add(_defaultApiClientHeader.Key, _defaultApiClientHeader.Value);
+
+            return await Client.SendAsync(request, completionOption, cancellationToken);
+        }
+    }
 }

--- a/src/Mscc.GenerativeAI/BaseModel.cs
+++ b/src/Mscc.GenerativeAI/BaseModel.cs
@@ -415,18 +415,9 @@ namespace Mscc.GenerativeAI
         protected async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default, HttpCompletionOption completionOption = HttpCompletionOption.ResponseContentRead)
         {
             // Add auth headers specific to this request
-            if (!string.IsNullOrEmpty(_apiKey))
-            {
-                request.Headers.Add("x-goog-api-key", _apiKey);
-            }
-            if (!string.IsNullOrEmpty(_accessToken))
-            {
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
-            }
-            if (!string.IsNullOrEmpty(_projectId))
-            {
-                request.Headers.Add("x-goog-user-project", _projectId);
-            }
+            AddApiKeyHeader(request);
+            AddAccessTokenHeader(request);
+            AddProjectIdHeader(request);
 
             // Add instance default headers
             request.Headers.UserAgent.Add(_defaultUserAgent);

--- a/src/Mscc.GenerativeAI/CachedContentModel.cs
+++ b/src/Mscc.GenerativeAI/CachedContentModel.cs
@@ -167,7 +167,6 @@ namespace Mscc.GenerativeAI
             url = ParseUrl(url).AddQueryString(queryStringParams);
             string json = Serialize(request);
             var payload = new StringContent(json, Encoding.UTF8, Constants.MediaType);
-#if NET472_OR_GREATER || NETSTANDARD2_0
             var message = new HttpRequestMessage
             {
                 Method = new HttpMethod("PATCH"),
@@ -176,9 +175,6 @@ namespace Mscc.GenerativeAI
                 Version = _httpVersion
             };
             var response = await SendAsync(message, cancellationToken);
-#else
-            var response = await SendAsync(message, cancellationToken);
-#endif
             await response.EnsureSuccessAsync();
             return await Deserialize<CachedContent>(response);
         }

--- a/src/Mscc.GenerativeAI/CachedContentModel.cs
+++ b/src/Mscc.GenerativeAI/CachedContentModel.cs
@@ -46,7 +46,11 @@ namespace Mscc.GenerativeAI
             url = ParseUrl(url);
             string json = Serialize(request);
             var payload = new StringContent(json, Encoding.UTF8, Constants.MediaType);
-            var response = await Client.PostAsync(url, payload, cancellationToken);
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = payload
+            };
+            var response = await SendAsync(httpRequest, cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<CachedContent>(response);
         }
@@ -109,7 +113,7 @@ namespace Mscc.GenerativeAI
             };
 
             url = ParseUrl(url).AddQueryString(queryStringParams);
-            var response = await Client.GetAsync(url, cancellationToken);
+            var response = await SendAsync(new HttpRequestMessage(HttpMethod.Get, url), cancellationToken);
             await response.EnsureSuccessAsync();
             var cachedContents = await Deserialize<ListCachedContentsResponse>(response);
             return cachedContents.CachedContents;
@@ -131,7 +135,7 @@ namespace Mscc.GenerativeAI
 
             var url = $"{BaseUrlGoogleAi}/{cachedContentName}";
             url = ParseUrl(url);
-            var response = await Client.GetAsync(url, cancellationToken);
+            var response = await SendAsync(new HttpRequestMessage(HttpMethod.Get, url), cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<CachedContent>(response);
         }
@@ -171,9 +175,9 @@ namespace Mscc.GenerativeAI
                 RequestUri = new Uri(url),
                 Version = _httpVersion
             };
-            var response = await Client.SendAsync(message);
+            var response = await SendAsync(message, cancellationToken);
 #else
-            var response = await Client.PatchAsync(url, payload, cancellationToken);
+            var response = await SendAsync(message, cancellationToken);
 #endif
             await response.EnsureSuccessAsync();
             return await Deserialize<CachedContent>(response);
@@ -195,7 +199,7 @@ namespace Mscc.GenerativeAI
 
             var url = $"{BaseUrlGoogleAi}/{cachedContentName}";
             url = ParseUrl(url);
-            var response = await Client.DeleteAsync(url, cancellationToken);
+            var response = await SendAsync(new HttpRequestMessage(HttpMethod.Delete, url), cancellationToken);
             await response.EnsureSuccessAsync();
 #if NET472_OR_GREATER || NETSTANDARD2_0
             return await response.Content.ReadAsStringAsync();

--- a/src/Mscc.GenerativeAI/ChatModel.cs
+++ b/src/Mscc.GenerativeAI/ChatModel.cs
@@ -53,7 +53,11 @@ namespace Mscc.GenerativeAI
             url = ParseUrl(url);
             string json = Serialize(request);
             var payload = new StringContent(json, Encoding.UTF8, Constants.MediaType);
-            var response = await Client.PostAsync(url, payload, cancellationToken);
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = payload
+            };
+            var response = await SendAsync(httpRequest, cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<ChatCompletionsResponse>(response);
         }

--- a/src/Mscc.GenerativeAI/ChatModel.cs
+++ b/src/Mscc.GenerativeAI/ChatModel.cs
@@ -15,13 +15,15 @@ namespace Mscc.GenerativeAI
         protected override string Version => ApiVersion.V1Beta;
         
         /// <inheritdoc cref="BaseModel"/>
-        public override string? ApiKey
+        protected override void AddApiKeyHeader(HttpRequestMessage request)
         {
-            set
+            if (!string.IsNullOrEmpty(_apiKey))
             {
-                _apiKey = value;
-                if (value != null)
-                    Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+                if (request.Headers.Contains("Authorization"))
+                {
+                    request.Headers.Remove("Authorization");
+                }
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
             }
         }
         

--- a/src/Mscc.GenerativeAI/FilesModel.cs
+++ b/src/Mscc.GenerativeAI/FilesModel.cs
@@ -47,7 +47,7 @@ namespace Mscc.GenerativeAI
             };
 
             url = ParseUrl(url).AddQueryString(queryStringParams);
-            var response = await Client.GetAsync(url, cancellationToken);
+            var response = await SendAsync(new HttpRequestMessage(HttpMethod.Get, url), cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<ListFilesResponse>(response);
         }
@@ -71,7 +71,7 @@ namespace Mscc.GenerativeAI
 
             var url = $"{BaseUrlGoogleAi}/{file}";
             url = ParseUrl(url);
-            var response = await Client.GetAsync(url, cancellationToken);
+            var response = await SendAsync(new HttpRequestMessage(HttpMethod.Get, url), cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<FileResource>(response);
         }
@@ -95,7 +95,7 @@ namespace Mscc.GenerativeAI
 
             var url = $"{BaseUrlGoogleAi}/{file}";   // v1beta3
             url = ParseUrl(url);
-            var response = await Client.DeleteAsync(url, cancellationToken);
+            var response = await SendAsync(new HttpRequestMessage(HttpMethod.Delete, url), cancellationToken);
             await response.EnsureSuccessAsync();
 #if NET472_OR_GREATER || NETSTANDARD2_0
             return await response.Content.ReadAsStringAsync();

--- a/src/Mscc.GenerativeAI/GeneratedFilesModel.cs
+++ b/src/Mscc.GenerativeAI/GeneratedFilesModel.cs
@@ -47,7 +47,7 @@ namespace Mscc.GenerativeAI
             };
 
             url = ParseUrl(url).AddQueryString(queryStringParams);
-            var response = await Client.GetAsync(url, cancellationToken);
+            var response = await SendAsync(new HttpRequestMessage(HttpMethod.Get, url), cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<ListGeneratedFilesResponse>(response);
         }

--- a/src/Mscc.GenerativeAI/ImageGenerationModel.cs
+++ b/src/Mscc.GenerativeAI/ImageGenerationModel.cs
@@ -88,7 +88,11 @@ namespace Mscc.GenerativeAI
             var url = ParseUrl(Url, Method);
             string json = Serialize(request);
             var payload = new StringContent(json, Encoding.UTF8, Constants.MediaType);
-            var response = await Client.PostAsync(url, payload, cancellationToken);
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = payload
+            };
+            var response = await SendAsync(httpRequest, cancellationToken);
             response.EnsureSuccessStatusCode();
             return await Deserialize<ImageGenerationResponse>(response);
         }

--- a/src/Mscc.GenerativeAI/ImageTextModel.cs
+++ b/src/Mscc.GenerativeAI/ImageTextModel.cs
@@ -57,7 +57,11 @@ namespace Mscc.GenerativeAI
             var url = ParseUrl(Url, Method);
             string json = Serialize(request);
             var payload = new StringContent(json, Encoding.UTF8, Constants.MediaType);
-            var response = await Client.PostAsync(url, payload, cancellationToken);
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = payload
+            };
+            var response = await SendAsync(httpRequest, cancellationToken);
             response.EnsureSuccessStatusCode();
             return await Deserialize<ImageTextResponse>(response);
         }

--- a/src/Mscc.GenerativeAI/ImagesModel.cs
+++ b/src/Mscc.GenerativeAI/ImagesModel.cs
@@ -45,7 +45,11 @@ namespace Mscc.GenerativeAI
             url = ParseUrl(url, Method);
             string json = Serialize(request);
             var payload = new StringContent(json, Encoding.UTF8, Constants.MediaType);
-            var response = await Client.PostAsync(url, payload, cancellationToken);
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = payload
+            };
+            var response = await SendAsync(httpRequest, cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<GenerateImagesResponse>(response);
         }

--- a/src/Mscc.GenerativeAI/MediaModel.cs
+++ b/src/Mscc.GenerativeAI/MediaModel.cs
@@ -86,8 +86,11 @@ namespace Mscc.GenerativeAI
                     ContentLength = totalBytes 
                 }
             });
-
-            var response = await Client.PostAsync(url, multipartContent, cancellationToken);
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = multipartContent
+            };
+            var response = await SendAsync(httpRequest, cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<UploadMediaResponse>(response);
         }
@@ -149,8 +152,11 @@ namespace Mscc.GenerativeAI
                     ContentLength = totalBytes 
                 }
             });
-
-            var response = await Client.PostAsync(url, multipartContent, cancellationToken);
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = multipartContent
+            };
+            var response = await SendAsync(httpRequest, cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<UploadMediaResponse>(response);
         }
@@ -185,7 +191,7 @@ namespace Mscc.GenerativeAI
                     ["alt"] = "media"
                 });
             }
-            var response = await Client.GetAsync(url, cancellationToken);
+            var response = await SendAsync(new HttpRequestMessage(HttpMethod.Get, url), cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<GeneratedFile>(response);
         }

--- a/src/Mscc.GenerativeAI/OpenAIModel.cs
+++ b/src/Mscc.GenerativeAI/OpenAIModel.cs
@@ -80,7 +80,7 @@ namespace Mscc.GenerativeAI
                     [nameof(model)] = model
                 });
             }
-            var response = await Client.GetAsync(url, cancellationToken);
+            var response = await SendAsync(new HttpRequestMessage(HttpMethod.Get, url), cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<SdkModel>(response);
         }
@@ -125,7 +125,11 @@ namespace Mscc.GenerativeAI
             url = ParseUrl(url);
             string json = Serialize(request);
             var payload = new StringContent(json, Encoding.UTF8, Constants.MediaType);
-            var response = await Client.PostAsync(url, payload, cancellationToken);
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = payload
+            };
+            var response = await SendAsync(httpRequest, cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<GenerateEmbeddingsResponse>(response);
         }
@@ -146,7 +150,11 @@ namespace Mscc.GenerativeAI
             url = ParseUrl(url);
             string json = Serialize(request);
             var payload = new StringContent(json, Encoding.UTF8, Constants.MediaType);
-            var response = await Client.PostAsync(url, payload, cancellationToken);
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = payload
+            };
+            var response = await SendAsync(httpRequest, cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<GenerateImagesResponse>(response);
         }

--- a/src/Mscc.GenerativeAI/OpenAIModel.cs
+++ b/src/Mscc.GenerativeAI/OpenAIModel.cs
@@ -15,14 +15,15 @@ namespace Mscc.GenerativeAI
     {
         protected override string Version => ApiVersion.V1Beta;
 
-        /// <inheritdoc cref="BaseModel"/>
-        public override string? ApiKey
+        protected override void AddApiKeyHeader(HttpRequestMessage request)
         {
-            set
+            if (!string.IsNullOrEmpty(_apiKey))
             {
-                _apiKey = value;
-                if (value != null)
-                    Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+                if (request.Headers.Contains("Authorization"))
+                {
+                    request.Headers.Remove("Authorization");
+                }
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
             }
         }
 
@@ -47,7 +48,9 @@ namespace Mscc.GenerativeAI
         {
             var url = $"{BaseUrlGoogleAi}/openai/models";
             url = ParseUrl(url);
-            var response = await Client.GetAsync(url, cancellationToken);
+            
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            var response = await SendAsync(request, cancellationToken);
             await response.EnsureSuccessAsync();
             var models = await Deserialize<SdkListModelsResponse>(response);
             return models;
@@ -96,8 +99,13 @@ namespace Mscc.GenerativeAI
             var url = $"{BaseUrlGoogleAi}/openai/chat/completions";
             url = ParseUrl(url);
             string json = Serialize(request);
-            var payload = new StringContent(json, Encoding.UTF8, Constants.MediaType);
-            var response = await Client.PostAsync(url, payload, cancellationToken);
+            
+            using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = new StringContent(json, Encoding.UTF8, Constants.MediaType)
+            };
+            
+            var response = await SendAsync(httpRequest, cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<ChatCompletionsResponse>(response);
         }

--- a/src/Mscc.GenerativeAI/SupervisedTuningJobModel.cs
+++ b/src/Mscc.GenerativeAI/SupervisedTuningJobModel.cs
@@ -58,7 +58,11 @@ namespace Mscc.GenerativeAI
             url = ParseUrl(url);
             string json = Serialize(request);
             var payload = new StringContent(json, Encoding.UTF8, Constants.MediaType);
-            var response = await Client.PostAsync(url, payload, cancellationToken);
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = payload
+            };
+            var response = await SendAsync(httpRequest, cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<TuningJob>(response);
         }
@@ -72,7 +76,7 @@ namespace Mscc.GenerativeAI
         {
             var url = $"{BaseUrlVertexAi}/tuningJobs";
             url = ParseUrl(url);
-            var response = await Client.GetAsync(url, cancellationToken);
+            var response = await SendAsync(new HttpRequestMessage(HttpMethod.Get, url), cancellationToken);
             await response.EnsureSuccessAsync();
             var tuningJobs = await Deserialize<ListTuningJobResponse>(response);
             return tuningJobs.TuningJobs;
@@ -94,7 +98,7 @@ namespace Mscc.GenerativeAI
 
             var url = $"{BaseUrlVertexAi}/{tuningJobId}";
             url = ParseUrl(url);
-            var response = await Client.GetAsync(url, cancellationToken);
+            var response = await SendAsync(new HttpRequestMessage(HttpMethod.Get, url), cancellationToken);
             await response.EnsureSuccessAsync();
             return await Deserialize<TuningJob>(response);
         }
@@ -117,7 +121,11 @@ namespace Mscc.GenerativeAI
             var url = $"{BaseUrlVertexAi}/{tuningJobId}:{method}";
             url = ParseUrl(url, method);
             var payload = new StringContent(string.Empty, Encoding.UTF8, Constants.MediaType);
-            var response = await Client.PostAsync(url, payload, cancellationToken);
+            var httpRequest = new HttpRequestMessage(HttpMethod.Post, url)
+            {
+                Content = payload
+            };
+            var response = await SendAsync(httpRequest, cancellationToken);
             await response.EnsureSuccessAsync();
 #if NET472_OR_GREATER || NETSTANDARD2_0
             return await response.Content.ReadAsStringAsync();
@@ -142,7 +150,7 @@ namespace Mscc.GenerativeAI
 
             var url = $"{BaseUrlVertexAi}/{tuningJobId}";
             url = ParseUrl(url);
-            var response = await Client.DeleteAsync(url, cancellationToken);
+            var response = await SendAsync(new HttpRequestMessage(HttpMethod.Delete, url), cancellationToken);
             await response.EnsureSuccessAsync();
 #if NET472_OR_GREATER || NETSTANDARD2_0
             return await response.Content.ReadAsStringAsync();

--- a/src/Mscc.GenerativeAI/Types/Generative/ResponseSchemaJsonConverter.cs
+++ b/src/Mscc.GenerativeAI/Types/Generative/ResponseSchemaJsonConverter.cs
@@ -22,7 +22,7 @@ namespace Mscc.GenerativeAI
         {
             var type = value.GetType();
             // How to figure out: type vs anonymous vs dynamic?
-            if (type.Name.Substring(0,Math.Min(type.Name.Length, 20)).Contains("AnonymousType"))
+            if (type == typeof(JsonDocument) || type.Name.Substring(0,Math.Min(type.Name.Length, 20)).Contains("AnonymousType"))
             {
                 var newOptions = new JsonSerializerOptions(options);
                 newOptions.Converters.Remove(this);


### PR DESCRIPTION
Client.DefaultRequestHeaders is not thread safe. I tried using the models in multiple threads and was running into some http client issues. I made it so each request is sent with its own request headers.

It also wasn't possible to provide a custom json schema instead of having one generated for you. I added a check that with let you provide a custom one if response schema is a json document.