### PR TITLE
add retry logic #2

### DIFF
--- a/src/Mscc.GenerativeAI/BaseModel.cs
+++ b/src/Mscc.GenerativeAI/BaseModel.cs
@@ -539,8 +539,15 @@ namespace Mscc.GenerativeAI
             var retry = requestOptions?.Retry ?? new Retry();
             var statusCodes = retry.StatusCodes ?? Constants.RetryStatusCodes;
             var delay = retry.Initial;
+            var stopwatch = Stopwatch.StartNew();
+
             for (var i = 0; i < retry.Maximum; i++)
             {
+                if (retry.Timeout.HasValue && stopwatch.Elapsed > retry.Timeout.Value)
+                {
+                    throw new TimeoutException("The request timed out.");
+                }
+
                 try
                 {
                     var response = await Client.SendAsync(request, completionOption, cancellationToken);

--- a/src/Mscc.GenerativeAI/BaseModel.cs
+++ b/src/Mscc.GenerativeAI/BaseModel.cs
@@ -562,6 +562,7 @@ namespace Mscc.GenerativeAI
                 }
                 catch (HttpRequestException e)
                 {
+                    Logger.LogWarning(e, "Request failed, attempting retry #{i + 1}.");
                     if (i == retry.Maximum - 1) throw;
                 }
 

--- a/src/Mscc.GenerativeAI/Constants/Constants.cs
+++ b/src/Mscc.GenerativeAI/Constants/Constants.cs
@@ -7,5 +7,6 @@ namespace Mscc.GenerativeAI
         internal const string MediaType = "application/json";
         internal const string RequestFailed = "Request failed";
         internal const string RequestFailedWithStatusCode = "Request failed with Status Code: ";
+        internal static readonly int[] RetryStatusCodes = [429, 500, 503, 504];
     }
 }

--- a/src/Mscc.GenerativeAI/Types/Generative/RequestOptions.cs
+++ b/src/Mscc.GenerativeAI/Types/Generative/RequestOptions.cs
@@ -58,5 +58,15 @@ namespace Mscc.GenerativeAI
         public int Multiplies { get; set; }
         public int Maximum { get; set; }
         public int Timeout { get; set; }
+        public int[]? StatusCodes { get; set; }
+
+        public Retry()
+        {
+            Initial = 1;
+            Multiplies = 2;
+            Maximum = 60;
+            Timeout = 120;
+            StatusCodes = Constants.RetryStatusCodes;
+        }
     }
 }

--- a/src/Mscc.GenerativeAI/Types/Generative/RequestOptions.cs
+++ b/src/Mscc.GenerativeAI/Types/Generative/RequestOptions.cs
@@ -66,7 +66,7 @@ namespace Mscc.GenerativeAI
             Multiplies = 2;
             Maximum = 60;
             Timeout = TimeSpan.FromSeconds(301);
-            StatusCodes = null;
+            StatusCodes = Constants.RetryStatusCodes;
         }
     }
 }

--- a/src/Mscc.GenerativeAI/Types/Generative/RequestOptions.cs
+++ b/src/Mscc.GenerativeAI/Types/Generative/RequestOptions.cs
@@ -52,21 +52,34 @@ namespace Mscc.GenerativeAI
         }
     }
 
+    /// <summary>
+    /// Defines the retry strategy for a request.
+    /// </summary>
     public class Retry
     {
-        public int Initial { get; set; }
-        public int Multiplies { get; set; }
-        public int Maximum { get; set; }
-        public TimeSpan? Timeout { get; set; }
-        public int[]? StatusCodes { get; set; }
+        /// <summary>
+        /// The initial delay before the first retry, in seconds.
+        /// </summary>
+        public int Initial { get; set; } = 1;
 
-        public Retry()
-        {
-            Initial = 1;
-            Multiplies = 2;
-            Maximum = 60;
-            Timeout = TimeSpan.FromSeconds(301);
-            StatusCodes = Constants.RetryStatusCodes;
-        }
+        /// <summary>
+        /// The multiplier for the delay between retries.
+        /// </summary>
+        public int Multiplies { get; set; } = 2;
+
+        /// <summary>
+        /// The maximum number of retries.
+        /// </summary>
+        public int Maximum { get; set; } = 60;
+
+        /// <summary>
+        /// The overall timeout for the retry logic.
+        /// </summary>
+        public TimeSpan? Timeout { get; set; } = TimeSpan.FromSeconds(301);
+
+        /// <summary>
+        /// The HTTP status codes that should trigger a retry.
+        /// </summary>
+        public int[]? StatusCodes { get; set; } = Constants.RetryStatusCodes;
     }
 }

--- a/src/Mscc.GenerativeAI/Types/Generative/RequestOptions.cs
+++ b/src/Mscc.GenerativeAI/Types/Generative/RequestOptions.cs
@@ -57,7 +57,7 @@ namespace Mscc.GenerativeAI
         public int Initial { get; set; }
         public int Multiplies { get; set; }
         public int Maximum { get; set; }
-        public int Timeout { get; set; }
+        public TimeSpan? Timeout { get; set; }
         public int[]? StatusCodes { get; set; }
 
         public Retry()
@@ -65,8 +65,8 @@ namespace Mscc.GenerativeAI
             Initial = 1;
             Multiplies = 2;
             Maximum = 60;
-            Timeout = 120;
-            StatusCodes = Constants.RetryStatusCodes;
+            Timeout = TimeSpan.FromSeconds(301);
+            StatusCodes = null;
         }
     }
 }


### PR DESCRIPTION
Implement Retry Logic in `BaseModel.cs`
* I'll modify the SendAsync method in BaseModel.cs to
incorporate the retry logic.
* A for loop will be added to wrap the Client.SendAsync call,
allowing for multiple retry attempts based on the
RequestOptions.Retry configuration.
* Inside the loop, a try-catch block will handle
HttpRequestException and check the response's status code
against the StatusCodes list.
* An exponential backoff strategy will be implemented for delays
between retries, using the Initial and Multiplies properties
from the Retry class. The delay will be capped by the Maximum
property to prevent excessively long waits.
* The overall retry duration will be constrained by the Timeout
property of the Retry class.
* If a request succeeds, the loop will terminate, and the
successful response will be returned.
* If all retry attempts are exhausted, the last exception will
be re-thrown to the caller.

This approach will create a robust and configurable retry mechanism
as requested in issue #2, integrating seamlessly with the existing
RequestOptions and Retry classes. The core logic will be centralized
in the SendAsync method for consistency.