### PR TITLE
Fix "instances" field bug and implement structure routing between Google AI and Vertex AI

### DIFF
--- a/src/Mscc.GenerativeAI/BaseModel.cs
+++ b/src/Mscc.GenerativeAI/BaseModel.cs
@@ -197,6 +197,11 @@ namespace Mscc.GenerativeAI
         }
 
         /// <summary>
+        /// Gets a value indicating whether the model is configured to use Vertex AI.
+        /// </summary>
+        internal virtual bool IsVertexAI => false;
+
+        /// <summary>
         /// A hook to verify if a specific request is supported by the current model configuration.
         /// Throws a <see cref="NotSupportedException"/> if the functionality is not supported.
         /// </summary>
@@ -358,6 +363,11 @@ namespace Mscc.GenerativeAI
         /// <returns>A JSON string representing the request.</returns>
         protected string Serialize<T>(T request)
         {
+            if (request is IVertexAware vertexAware)
+            {
+                vertexAware.PrepareForSerialization(IsVertexAI);
+            }
+
             var json = JsonSerializer.Serialize(request, WriteOptions);
 
             Logger.LogJsonRequest(TruncateJsonForLogging(json));

--- a/src/Mscc.GenerativeAI/GenerativeModel.cs
+++ b/src/Mscc.GenerativeAI/GenerativeModel.cs
@@ -1930,23 +1930,26 @@ namespace Mscc.GenerativeAI
             var method = GenerativeAI.Types.Method.CountTokens;
             var url = ParseUrl(Url, method);
 
+            CountTokensRequest countTokensRequest;
             if (_useVertexAi)
             {
-                var countRequest = new CountTokensRequest()
-                {
-                    Instances = new List<object>(request.Contents),
-                    GenerationConfig = request.GenerationConfig,
-                    Tools = request.Tools,
-                    SystemInstruction = request.SystemInstruction
-                };
-                return await PostAsync<CountTokensRequest, CountTokensResponse>(countRequest, url, method, requestOptions, HttpCompletionOption.ResponseContentRead, cancellationToken);
+	            countTokensRequest = new CountTokensRequest()
+	            {
+		            Instances = request.Contents is null ? null : [..request.Contents],
+		            GenerationConfig = request.GenerationConfig,
+		            Tools = request.Tools,
+		            SystemInstruction = request.SystemInstruction
+	            };
             }
-
-            var countTokensRequest = new CountTokensRequest()
+            else
             {
-                GenerateContentRequest = request
-            };
+	            countTokensRequest = new CountTokensRequest()
+	            {
+		            GenerateContentRequest = request
+	            };
+            }
             return await PostAsync<CountTokensRequest, CountTokensResponse>(countTokensRequest, url, method, requestOptions, HttpCompletionOption.ResponseContentRead, cancellationToken);
+
         }
 
         /// <remarks/>

--- a/src/Mscc.GenerativeAI/GenerativeModel.cs
+++ b/src/Mscc.GenerativeAI/GenerativeModel.cs
@@ -183,7 +183,7 @@ namespace Mscc.GenerativeAI
         /// <summary>
         /// Gets a value indicating whether the model is configured to use Vertex AI.
         /// </summary>
-        internal bool IsVertexAI => _useVertexAi;
+        internal override bool IsVertexAI => _useVertexAi;
 
         /// <summary>
         /// You can enable Server Sent Events (SSE) for gemini-1.0-pro
@@ -1759,8 +1759,9 @@ namespace Mscc.GenerativeAI
             if (!string.IsNullOrEmpty(title) && taskType != TaskType.RetrievalDocument) throw new NotSupportedException("If a title is specified, the task must be a retrieval document type task.");
 
             var method = GenerativeAI.Types.Method.BatchEmbedContents;
+            var request = new BatchEmbedContentsRequest { Requests = requests };
             var url = ParseUrl(Url, method);
-            return await PostAsync<List<EmbedContentRequest>, EmbedContentResponse>(requests, url, method, requestOptions, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            return await PostAsync<BatchEmbedContentsRequest, EmbedContentResponse>(request, url, method, requestOptions, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <summary>
@@ -1928,14 +1929,24 @@ namespace Mscc.GenerativeAI
 
             var method = GenerativeAI.Types.Method.CountTokens;
             var url = ParseUrl(Url, method);
-            var json = Serialize(request);
-            var payload = new StringContent(json, Encoding.UTF8, Constants.MediaType);
 
-            using var httpRequest = new HttpRequestMessage(HttpMethod.Post, url);
-            httpRequest.Content = payload;
-            var response = await SendAsync(httpRequest, requestOptions, cancellationToken);
-            await response.EnsureSuccessAsync(cancellationToken);
-            return await Deserialize<CountTokensResponse>(response);
+            if (_useVertexAi)
+            {
+                var countRequest = new CountTokensRequest()
+                {
+                    Instances = new List<object>(request.Contents),
+                    GenerationConfig = request.GenerationConfig,
+                    Tools = request.Tools,
+                    SystemInstruction = request.SystemInstruction
+                };
+                return await PostAsync<CountTokensRequest, CountTokensResponse>(countRequest, url, method, requestOptions, HttpCompletionOption.ResponseContentRead, cancellationToken);
+            }
+
+            var countTokensRequest = new CountTokensRequest()
+            {
+                GenerateContentRequest = request
+            };
+            return await PostAsync<CountTokensRequest, CountTokensResponse>(countTokensRequest, url, method, requestOptions, HttpCompletionOption.ResponseContentRead, cancellationToken);
         }
 
         /// <remarks/>
@@ -2040,7 +2051,7 @@ namespace Mscc.GenerativeAI
             
             if (request == null) throw new ArgumentNullException(nameof(request));
 
-            var method = GenerativeAI.Types.Method.CountTokens;
+            var method = GenerativeAI.Types.Method.ComputeTokens;
             var url = ParseUrl(Url, method);
             var json = Serialize(request);
             var payload = new StringContent(json, Encoding.UTF8, Constants.MediaType);

--- a/src/Mscc.GenerativeAI/ImageGenerationModel.cs
+++ b/src/Mscc.GenerativeAI/ImageGenerationModel.cs
@@ -26,7 +26,7 @@ namespace Mscc.GenerativeAI
         
         private string Method => GenerativeAI.Types.Method.Predict;
         
-        internal bool IsVertexAI => _useVertexAi;
+        internal override bool IsVertexAI => _useVertexAi;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImageGenerationModel"/> class.

--- a/src/Mscc.GenerativeAI/Types/BatchEmbedContentsRequest.cs
+++ b/src/Mscc.GenerativeAI/Types/BatchEmbedContentsRequest.cs
@@ -1,0 +1,16 @@
+namespace Mscc.GenerativeAI.Types
+{
+	public partial class BatchEmbedContentsRequest : IVertexAware
+	{
+		public void PrepareForSerialization(bool useVertexAi)
+		{
+			if (Requests != null)
+			{
+				foreach (var request in Requests)
+				{
+					request.PrepareForSerialization(useVertexAi);
+				}
+			}
+		}
+	}
+}

--- a/src/Mscc.GenerativeAI/Types/ComputeTokensRequest.cs
+++ b/src/Mscc.GenerativeAI/Types/ComputeTokensRequest.cs
@@ -5,11 +5,38 @@ namespace Mscc.GenerativeAI.Types
     /// <summary>
     /// Request message for ComputeTokens RPC call.
     /// </summary>
-    public partial class ComputeTokensRequest
+    public partial class ComputeTokensRequest : IVertexAware
     {
         /// <summary>
         /// Optional parameters for the request.
         /// </summary>
         public ComputeTokensConfig? Config { get; set; }
+
+        public void PrepareForSerialization(bool useVertexAi)
+        {
+            if (useVertexAi)
+            {
+                if (Contents != null && Instances == null)
+                {
+                    Instances = new List<object>(Contents);
+                    Contents = null;
+                }
+            }
+            else
+            {
+                if (Instances != null && Contents == null)
+                {
+                    Contents = new List<Content>();
+                    foreach (var instance in Instances)
+                    {
+                        if (instance is Content content)
+                        {
+                            Contents.Add(content);
+                        }
+                    }
+                    Instances = null;
+                }
+            }
+        }
     }
 }

--- a/src/Mscc.GenerativeAI/Types/CountTokensRequest.cs
+++ b/src/Mscc.GenerativeAI/Types/CountTokensRequest.cs
@@ -14,16 +14,45 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
+
 namespace Mscc.GenerativeAI.Types
 {
 	/// <summary>
 	/// Request for counting tokens.
 	/// </summary>
-	public partial class CountTokensRequest
+	public partial class CountTokensRequest : IVertexAware
 	{
 		/// <summary>
 		/// Configuration for counting tokens.
 		/// </summary>
 		public CountTokensConfig? Config { get; set; }
+
+		public void PrepareForSerialization(bool useVertexAi)
+		{
+			if (useVertexAi)
+			{
+				if (Contents != null && Instances == null)
+				{
+					Instances = new List<object>(Contents);
+					Contents = null;
+				}
+			}
+			else
+			{
+				if (Instances != null && Contents == null)
+				{
+					Contents = new List<Content>();
+					foreach (var instance in Instances)
+					{
+						if (instance is Content content)
+						{
+							Contents.Add(content);
+						}
+					}
+					Instances = null;
+				}
+			}
+		}
 	}
 }

--- a/src/Mscc.GenerativeAI/Types/EmbedContentRequest.cs
+++ b/src/Mscc.GenerativeAI/Types/EmbedContentRequest.cs
@@ -21,12 +21,17 @@ namespace Mscc.GenerativeAI.Types
 	/// <summary>
 	/// Request containing the <see cref="Content"/> for the model to embed.
 	/// </summary>
-	public partial class EmbedContentRequest
+	public partial class EmbedContentRequest : IVertexAware
 	{
 		/// <summary>
 		/// Required. The content to embed. Only the <see cref="parts.text"/> fields will be counted.
 		/// </summary>
 		public ContentResponse? Content { get; set; }
+
+		/// <summary>
+		/// Required. The content to embed. For Vertex AI.
+		/// </summary>
+		public object? Instance { get; set; }
 
 		/// <summary>
 		/// 
@@ -55,6 +60,29 @@ namespace Mscc.GenerativeAI.Types
 				{
 					Text = prompt
 				});
+			}
+		}
+
+		public void PrepareForSerialization(bool useVertexAi)
+		{
+			if (useVertexAi)
+			{
+				if (Content != null && Instance == null)
+				{
+					Instance = Content;
+					Content = null;
+				}
+			}
+			else
+			{
+				if (Instance != null && Content == null)
+				{
+					if (Instance is ContentResponse contentResponse)
+					{
+						Content = contentResponse;
+					}
+					Instance = null;
+				}
 			}
 		}
 	}

--- a/src/Mscc.GenerativeAI/Types/IVertexAware.cs
+++ b/src/Mscc.GenerativeAI/Types/IVertexAware.cs
@@ -1,0 +1,14 @@
+namespace Mscc.GenerativeAI.Types
+{
+    /// <summary>
+    /// Interface for request objects that need to adapt their structure based on whether Vertex AI is being used.
+    /// </summary>
+    internal interface IVertexAware
+    {
+        /// <summary>
+        /// Prepares the request object for serialization.
+        /// </summary>
+        /// <param name="useVertexAi">Flag indicating whether Vertex AI is being used.</param>
+        void PrepareForSerialization(bool useVertexAi);
+    }
+}

--- a/tests/Mscc.GenerativeAI/SerializationTests.cs
+++ b/tests/Mscc.GenerativeAI/SerializationTests.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Mscc.GenerativeAI;
+using Mscc.GenerativeAI.Types;
+using Shouldly;
+using Xunit;
+
+namespace Test.Mscc.GenerativeAI
+{
+    public class SerializationTests
+    {
+        private class MockHttpMessageHandler : HttpMessageHandler
+        {
+            public string LastPayload { get; private set; }
+            public HttpRequestMessage LastRequest { get; private set; }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastRequest = request;
+                if (request.Content != null)
+                {
+                    LastPayload = await request.Content.ReadAsStringAsync();
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{}")
+                };
+            }
+        }
+
+        [Fact]
+        public async Task EmbedContent_List_Should_Use_BatchEmbedContentsRequest()
+        {
+            // Arrange
+            var handler = new MockHttpMessageHandler();
+            var model = new GenerativeModel(handler);
+            var requests = new List<EmbedContentRequest>
+            {
+                new EmbedContentRequest("Hello"),
+                new EmbedContentRequest("World")
+            };
+
+            // Act
+            await model.EmbedContent(requests);
+
+            // Assert
+            handler.LastPayload.ShouldNotBeNull();
+            var json = JsonDocument.Parse(handler.LastPayload);
+            json.RootElement.TryGetProperty("requests", out _).ShouldBeTrue();
+            json.RootElement.TryGetProperty("instances", out _).ShouldBeFalse();
+
+            var requestsArray = json.RootElement.GetProperty("requests");
+            requestsArray.GetArrayLength().ShouldBe(2);
+            requestsArray[0].GetProperty("content").GetProperty("parts")[0].GetProperty("text").GetString().ShouldBe("Hello");
+        }
+
+        [Fact]
+        public async Task GenerateImages_Should_Use_Instances()
+        {
+            // Arrange
+            var handler = new MockHttpMessageHandler();
+            var request = new GenerateImagesRequest("A futuristic city");
+
+            // Act
+            var genModel = new GenerativeModel(handler);
+            await genModel.GenerateImages(request);
+
+            // Assert
+            handler.LastPayload.ShouldNotBeNull();
+            var json = JsonDocument.Parse(handler.LastPayload);
+            json.RootElement.TryGetProperty("instances", out _).ShouldBeTrue();
+            json.RootElement.TryGetProperty("requests", out _).ShouldBeFalse();
+
+            var instancesArray = json.RootElement.GetProperty("instances");
+            instancesArray.GetArrayLength().ShouldBe(1);
+            instancesArray[0].GetProperty("prompt").GetString().ShouldBe("A futuristic city");
+        }
+
+        [Fact]
+        public async Task CountTokens_GoogleAI_Should_Use_Contents()
+        {
+            // Arrange
+            var handler = new MockHttpMessageHandler();
+            var model = new GenerativeModel(handler); // Default is Google AI
+            var request = new GenerateContentRequest("Hello");
+
+            // Act
+            await model.CountTokens(request);
+
+            // Assert
+            handler.LastPayload.ShouldNotBeNull();
+            var json = JsonDocument.Parse(handler.LastPayload);
+            json.RootElement.TryGetProperty("generateContentRequest", out _).ShouldBeTrue();
+            json.RootElement.GetProperty("generateContentRequest").TryGetProperty("contents", out _).ShouldBeTrue();
+            json.RootElement.TryGetProperty("instances", out _).ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task CountTokens_VertexAI_Should_Use_Instances_And_Preserve_Data()
+        {
+            // Arrange
+            var handler = new MockHttpMessageHandler();
+            var model = new GenerativeModel("dummy_project", "us-central1", "dummy_model", "dummy_token", endpoint: null, generationConfig: null, safetySettings: null, tools: null, systemInstruction: null, toolConfig: null, httpClientFactory: null, logger: null);
+            typeof(BaseModel).GetField("_httpClient", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).SetValue(model, new HttpClient(handler));
+            var request = new GenerateContentRequest("Hello")
+            {
+                GenerationConfig = new GenerationConfig { Temperature = 0.5f },
+                Tools = new Tools { new Tool { GoogleSearchRetrieval = new GoogleSearchRetrieval() } },
+                SystemInstruction = new Content("Be a helpful assistant")
+            };
+
+            // Act
+            await model.CountTokens(request);
+
+            // Assert
+            handler.LastPayload.ShouldNotBeNull();
+            var json = JsonDocument.Parse(handler.LastPayload);
+            json.RootElement.TryGetProperty("instances", out _).ShouldBeTrue();
+            json.RootElement.TryGetProperty("generationConfig", out _).ShouldBeTrue();
+            json.RootElement.GetProperty("generationConfig").GetProperty("temperature").GetSingle().ShouldBe(0.5f);
+            json.RootElement.TryGetProperty("tools", out _).ShouldBeTrue();
+            json.RootElement.TryGetProperty("systemInstruction", out _).ShouldBeTrue();
+            json.RootElement.GetProperty("systemInstruction").GetProperty("parts")[0].GetProperty("text").GetString().ShouldBe("Be a helpful assistant");
+
+            json.RootElement.TryGetProperty("generateContentRequest", out _).ShouldBeFalse();
+            json.RootElement.TryGetProperty("contents", out _).ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task EmbedContent_GoogleAI_Should_Use_Content()
+        {
+            // Arrange
+            var handler = new MockHttpMessageHandler();
+            var model = new GenerativeModel(); // Default is Google AI
+            typeof(BaseModel).GetField("_httpClient", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).SetValue(model, new HttpClient(handler));
+
+            // Act
+            await model.EmbedContent("Hello");
+
+            // Assert
+            handler.LastPayload.ShouldNotBeNull();
+            var json = JsonDocument.Parse(handler.LastPayload);
+            json.RootElement.TryGetProperty("content", out _).ShouldBeTrue();
+            json.RootElement.TryGetProperty("instance", out _).ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task EmbedContent_VertexAI_Should_Use_Instance()
+        {
+            // Arrange
+            var handler = new MockHttpMessageHandler();
+            var model = new GenerativeModel("dummy_project", "us-central1", "dummy_model", "dummy_token", endpoint: null, generationConfig: null, safetySettings: null, tools: null, systemInstruction: null, toolConfig: null, httpClientFactory: null, logger: null);
+            typeof(BaseModel).GetField("_httpClient", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).SetValue(model, new HttpClient(handler));
+
+            // Act
+            await model.EmbedContent("Hello");
+
+            // Assert
+            handler.LastPayload.ShouldNotBeNull();
+            var json = JsonDocument.Parse(handler.LastPayload);
+            json.RootElement.TryGetProperty("instance", out _).ShouldBeTrue();
+            json.RootElement.TryGetProperty("content", out _).ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task ComputeTokens_VertexAI_Should_Use_Instances()
+        {
+            // Arrange
+            var handler = new MockHttpMessageHandler();
+            var model = new GenerativeModel("dummy_project", "us-central1", "dummy_model", "dummy_token", endpoint: null, generationConfig: null, safetySettings: null, tools: null, systemInstruction: null, toolConfig: null, httpClientFactory: null, logger: null);
+            typeof(BaseModel).GetField("_httpClient", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).SetValue(model, new HttpClient(handler));
+            var request = new ComputeTokensRequest
+            {
+                Contents = new List<Content> { new Content { Role = "user", Parts = new List<IPart> { new TextData { Text = "Hello" } } } }
+            };
+
+            // Act
+            await model.ComputeTokens(request);
+
+            // Assert
+            handler.LastPayload.ShouldNotBeNull();
+            var json = JsonDocument.Parse(handler.LastPayload);
+            json.RootElement.TryGetProperty("instances", out _).ShouldBeTrue();
+            json.RootElement.TryGetProperty("contents", out _).ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task ComputeTokens_GoogleAI_Should_Use_Contents()
+        {
+            // Arrange
+            var handler = new MockHttpMessageHandler();
+            var model = new GenerativeModel(); // Default is Google AI
+            typeof(BaseModel).GetField("_httpClient", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance).SetValue(model, new HttpClient(handler));
+            var request = new ComputeTokensRequest
+            {
+                Instances = new List<object> { new Content { Role = "user", Parts = new List<IPart> { new TextData { Text = "Hello" } } } }
+            };
+
+            // Act
+            // ComputeTokens throws if not useVertexAi, let's use a workaround to test the serialization part
+            // or just verify the PrepareForSerialization directly.
+            request.PrepareForSerialization(false);
+            var options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            {
+                DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            };
+            var jsonStr = JsonSerializer.Serialize(request, options);
+
+            // Assert
+            var json = JsonDocument.Parse(jsonStr);
+            json.RootElement.TryGetProperty("contents", out _).ShouldBeTrue();
+            json.RootElement.TryGetProperty("instances", out _).ShouldBeFalse();
+        }
+    }
+}


### PR DESCRIPTION
This pull request fixes the "Unknown name 'instances'" error and implements dynamic payload routing between Google AI and Vertex AI platforms.

Key changes:
1.  **Bug Fix in Batch Embeddings**: `EmbedContent` now correctly wraps lists of requests in a `BatchEmbedContentsRequest` object.
2.  **Platform-Aware Serialization**: Introduced the `IVertexAware` interface, which allows request objects to adjust their internal structure (e.g., swapping between `contents` and `instances` properties) just before serialization based on the target platform.
3.  **Data Preservation**: Fixed a regression in `CountTokens` where metadata (like `GenerationConfig`) was being lost when calling Vertex AI.
4.  **Architectural Improvements**: Added a virtual `IsVertexAI` property to `BaseModel` for better extensibility and refactored API calls to use the standard `PostAsync` helper.
5.  **Verified fix**: Added a comprehensive set of unit tests in `SerializationTests.cs` to ensure that the generated JSON payloads are correct for both Google AI and Vertex AI contexts across multiple request types.

---
*PR created automatically by Jules for task [3732281247069346569](https://jules.google.com/task/3732281247069346569) started by @jochenkirstaetter*