### PR TITLE
Do not set MimeType in upload request; add explanatory comment

### DIFF
--- a/src/Mscc.GenerativeAI/FileSearchStoresModel.cs
+++ b/src/Mscc.GenerativeAI/FileSearchStoresModel.cs
@@ -274,9 +274,11 @@ namespace Mscc.GenerativeAI
             
             var request = config ?? new UploadToFileSearchStoreRequest();
             request.DisplayName ??= displayName ?? Path.GetFileNameWithoutExtension(file);
-            request.MimeType ??= mimeType;
+			// The API will detect the MIME type from the file content. The `mimeType` property in the request is only for user reference and won't affect the actual MIME type detection and processing in the API.
+			// So we don't need to set it in the request.
+			//request.MimeType ??= mimeType;
 
-            var baseUri = BaseUrlGoogleAi.ToLowerInvariant().Replace("/{version}", "");
+			var baseUri = BaseUrlGoogleAi.ToLowerInvariant().Replace("/{version}", "");
             var url = $"{baseUri}/upload/{Version}/{name}:uploadToFileSearchStore";   // v1beta3 // ?key={apiKey}
             if (resumable)
             { 
@@ -341,9 +343,11 @@ namespace Mscc.GenerativeAI
             var totalBytes = stream.Length;
             var request = config ?? new UploadToFileSearchStoreRequest();
             request.DisplayName ??= displayName;
-            request.MimeType ??= mimeType;
+			// The API will detect the MIME type from the file content. The `mimeType` property in the request is only for user reference and won't affect the actual MIME type detection and processing in the API.
+			// So we don't need to set it in the request.
+			//request.MimeType ??= mimeType;
 
-            var baseUri = BaseUrlGoogleAi.ToLowerInvariant().Replace("/{version}", "");
+			var baseUri = BaseUrlGoogleAi.ToLowerInvariant().Replace("/{version}", "");
             var url = $"{baseUri}/upload/{Version}/{name}:uploadToFileSearchStore";   // v1beta3 // ?key={apiKey}
             if (resumable)
             { 


### PR DESCRIPTION
Hi! Excellent work. I have been using this library for a few months without any issues.

I usually use it to upload PDF files to the File Search Storage API using the proper `UploadToFileSearchStoreRequest` method. It works well, but yesterday I tried to upload a DOCX document with a valid MIME type (`application/vnd.openxmlformats-officedocument.wordprocessingml.document`), and I got the following Google error:

```json
{
  "error": {
    "code": 400,
    "message": "* UploadToFileSearchStoreRequest.mime_type: When provided, MIME type must be in a valid type/subtype format (e.g., 'text/plain', 'application/pdf').\n",
    "status": "INVALID_ARGUMENT"
  }
}
```

So I checked the official documentation and tried other MIME types, such as `application/msword`, but nothing worked.

I checked the documentation here:

https://ai.google.dev/gemini-api/docs/file-search#application
https://ai.google.dev/gemini-api/docs/file-search#text

Finally, I searched online and found other people with the same issue: files are not uploaded when a valid and supported `mimeType` is set in the request. Only TXT and PDF seem to work by default.

https://github.com/googleapis/python-genai/issues/1900
https://discuss.ai.google.dev/t/upload-word-and-excel-file-to-google-file-search/110281/12

So I made a small change in your library and commented out the MIME type assignment in the upload methods. Google detects and resolves it without any issues when the MIME type is not sent in the request body. However, the MIME type parameter is still used for the `Content-Type` request header, which works fine.

According to the API definition, `mimeType` is optional. When it is not provided, it is resolved by the backend:

https://ai.google.dev/api/file-search/file-search-stores

Please check this when you can. Thanks in advance!
